### PR TITLE
Improve camera performance and remove ability to switch to legacy camera

### DIFF
--- a/app/src/main/java/tv/remo/android/controller/fragments/SettingsCamera.kt
+++ b/app/src/main/java/tv/remo/android/controller/fragments/SettingsCamera.kt
@@ -4,6 +4,7 @@ import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.os.Build
 import android.os.Bundle
+import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
 import tv.remo.android.controller.R
 import tv.remo.android.controller.sdk.RemoSettingsUtil
@@ -18,14 +19,11 @@ class SettingsCamera : BasePreferenceFragmentCompat(
                 RemoSettingsUtil.with(context!!){
                         val supportsCamera2 = validateCamera2Support(context!!,
                                 it.cameraDeviceId.getPref())
-                        val switchPref = findPreference<SwitchPreferenceCompat>(getString(R.string.useCamera2))
-                        if(!supportsCamera2){
-                                switchPref?.isChecked = false
-                                switchPref?.isEnabled = false
-                        }
-                        else{
-                                switchPref?.isEnabled = true
-                        }
+                        val disabledPref = findPreference<Preference>(getString(R.string.camera2features))
+                        disabledPref?.isVisible = !supportsCamera2
+                        val featureSwitch = findPreference<SwitchPreferenceCompat>(getString(R.string.useCamera2))
+                        featureSwitch?.isEnabled = supportsCamera2
+                        featureSwitch?.isChecked = supportsCamera2
                 }
         }
 

--- a/app/src/main/java/tv/remo/android/controller/fragments/SettingsCamera.kt
+++ b/app/src/main/java/tv/remo/android/controller/fragments/SettingsCamera.kt
@@ -1,8 +1,48 @@
 package tv.remo.android.controller.fragments
+import android.content.Context
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.os.Build
+import android.os.Bundle
+import androidx.preference.SwitchPreferenceCompat
 import tv.remo.android.controller.R
+import tv.remo.android.controller.sdk.RemoSettingsUtil
 import tv.remo.android.settingsutil.fragments.BasePreferenceFragmentCompat
 
 class SettingsCamera : BasePreferenceFragmentCompat(
         R.xml.settings_camera,
         R.string.cameraSettingsEnableKey
-)
+){
+        override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+                super.onCreatePreferences(savedInstanceState, rootKey)
+                RemoSettingsUtil.with(context!!){
+                        val supportsCamera2 = validateCamera2Support(context!!,
+                                it.cameraDeviceId.getPref())
+                        val switchPref = findPreference<SwitchPreferenceCompat>(getString(R.string.useCamera2))
+                        if(!supportsCamera2){
+                                switchPref?.isChecked = false
+                                switchPref?.isEnabled = false
+                        }
+                        else{
+                                switchPref?.isEnabled = true
+                        }
+                }
+        }
+
+        private fun validateCamera2Support(context: Context, cameraId: Int): Boolean {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        try {
+                                val cm =
+                                        (context.getSystemService(Context.CAMERA_SERVICE) as CameraManager)
+                                val hardwareLevel = cm.getCameraCharacteristics(
+                                        cm.cameraIdList[cameraId]
+                                )[CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL]
+                                return hardwareLevel != CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY
+                                        && hardwareLevel != CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LIMITED
+                        } catch (_: Exception) {
+
+                        }
+                }
+                return false
+        }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,17 +51,14 @@
     <string name="cameraSettingsSummary">Resolution, Orientation, Bitrate</string>
     <string name="cameraResolutionTitle">Resolution</string>
     <string name="cameraOrientationTitle">Orientation</string>
-    <string name="camera2EnabledTitle">Use Camera2 API</string>
-    <string name="camera2EnabledSummary">Use the Camera API introduced in Android 5.0.0 (API21).
-        Try disabling if device is not rendering fast enough. Locks the resolution to 640x480 when disabled.
-        Disabled if device does not support it</string>
-
+    <string name="camera2DisabledTitle">Camera2 Disabled</string>
+    <string name="camera2DisabledSummary">Device is using legacy camera API.
+        Resolution is locked at 640x480. Disabled since device OS is below 5.0
+        or selected camera id does not support new camera api</string>
     <!--Microphone-->
     <string name="microphoneSettingsTitle">Microphone</string>
     <string name="microphoneSettingsSummary">Volume, Bitrate</string>
     <string name="micVolumeBoostTitle">Volume Boost</string>
-
-
     <!--Audio/Speaker-->
     <string name="audioSettingsTitle">Audio and Commands</string>
     <string name="audioSettingsSummary">Text to Speech, Device Volume, Commands</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,8 +51,10 @@
     <string name="cameraSettingsSummary">Resolution, Orientation, Bitrate</string>
     <string name="cameraResolutionTitle">Resolution</string>
     <string name="cameraOrientationTitle">Orientation</string>
-    <string name="camera2EnabledTitle">Use New Camera API</string>
-    <string name="camera2EnabledSummary">Use the Camera API introduced in Lollipop (21). Try disabling if device is not rendering fast enough. Locks the resolution to 640x480 when disabled</string>
+    <string name="camera2EnabledTitle">Use Camera2 API</string>
+    <string name="camera2EnabledSummary">Use the Camera API introduced in Android 5.0.0 (API21).
+        Try disabling if device is not rendering fast enough. Locks the resolution to 640x480 when disabled.
+        Disabled if device does not support it</string>
 
     <!--Microphone-->
     <string name="microphoneSettingsTitle">Microphone</string>

--- a/app/src/main/res/xml/settings_camera.xml
+++ b/app/src/main/res/xml/settings_camera.xml
@@ -7,7 +7,7 @@
         <SwitchPreferenceCompat
             app:key="@string/useCamera2"
             app:defaultValue="@string/camera2supported"
-            app:enabled="@string/camera2supported"
+            app:enabled="false"
             app:title="@string/camera2EnabledTitle"
             app:summary="@string/camera2EnabledSummary"/>
         <androidx.preference.ListPreference
@@ -18,7 +18,6 @@
             app:useSimpleSummaryProvider="true"
             app:entries="@array/resolution_pref_list"
             app:entryValues="@array/resolution_pref_list"/>
-
         <androidx.preference.ListPreference
             app:key="@string/cameraOrientationKey"
             app:title="@string/cameraOrientationTitle"

--- a/app/src/main/res/xml/settings_camera.xml
+++ b/app/src/main/res/xml/settings_camera.xml
@@ -4,12 +4,16 @@
     <PreferenceCategory
         app:key="@string/cameraSettingsGeneralGroupKey"
         app:title="@string/generalSettings">
+        <Preference
+                app:key="@string/camera2features"
+                app:isPreferenceVisible="false"
+                app:title="@string/camera2DisabledTitle"
+                app:summary="@string/camera2DisabledSummary"/>
         <SwitchPreferenceCompat
             app:key="@string/useCamera2"
             app:defaultValue="@string/camera2supported"
             app:enabled="false"
-            app:title="@string/camera2EnabledTitle"
-            app:summary="@string/camera2EnabledSummary"/>
+            app:isPreferenceVisible="false"/>
         <androidx.preference.ListPreference
             app:key="@string/cameraResolutionKey"
             app:dependency="@string/useCamera2"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    def controlsdk_version = "0.5.0"
+    def controlsdk_version = "0.6.0"
     api "org.btelman.controlsdk:core:$controlsdk_version"
     api "org.btelman.controlsdk:streaming:$controlsdk_version"
     api "org.btelman.controlsdk:hardware:$controlsdk_version"

--- a/sdk/src/main/res/values/preferences.xml
+++ b/sdk/src/main/res/values/preferences.xml
@@ -43,5 +43,5 @@
     <string name="internalCommandBlocking">internalCommandBlockingKey</string>
     <string name="internalCommandsToBlock">internalCommandsBlockingArrayKey</string>
     <string name="serverOwnerKey">serverOwnerKey</string>
-    <string name="camera2features" />
+    <string name="camera2features">camera2featuresKey</string>
 </resources>

--- a/sdk/src/main/res/values/preferences.xml
+++ b/sdk/src/main/res/values/preferences.xml
@@ -43,4 +43,5 @@
     <string name="internalCommandBlocking">internalCommandBlockingKey</string>
     <string name="internalCommandsToBlock">internalCommandsBlockingArrayKey</string>
     <string name="serverOwnerKey">serverOwnerKey</string>
+    <string name="camera2features" />
 </resources>


### PR DESCRIPTION
Ability to switch to legacy camera removed since the sdk now detects and switches to the camera1 api automatically if device is using the legacy api already. This was initially done since devices like the Samsung Galaxy S4 would lag really badly, due to only having legacy support, and not being able to benefit from camera2 api.

Resolution changing still gets disabled if using the legacy camera api for now