### PR TITLE
Convert `/` commands to `.` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,41 +76,41 @@ with settings that can be changed. Going into the connection section will bring 
 Only the owner can use this.
 Turns on table top mode, not allowing 'f' and 'b' commands, but allows everything else. Not case sensitive
 
-On: `/table on`
+On: `.table on`
 
-Off: `/table off`
+Off: `.table off`
 
-Toggle on and off: `/stationary`
+Toggle on and off: `.stationary`
 
 The robot has to handle this command, unless set in the app settings to be handled locally. The option exists for both since some hardware is not programmable, such as a sabertooth serial controller. In the case that the app controls it, the list of restricted controls are configurable as well
 
 #### Exclusive Control ####
 
-`/xcontrol user 60`: give user user control of robot for 60 seconds
-`/xcontrol ~ 60` (button): give user who pressed the button exclusive control for 60 seconds
-`/xcontrol user`: user user gets exclusive control indefinitely or until the robot reboots
-`/xcontrol off`: turn off exclusive control
+`.xcontrol user 60`: give user user control of robot for 60 seconds
+`.xcontrol ~ 60` (button): give user who pressed the button exclusive control for 60 seconds
+`.xcontrol user`: user user gets exclusive control indefinitely or until the robot reboots
+`.xcontrol off`: turn off exclusive control
 
 #### Dev mode ####
 Only works if the owner is added to settings in the connection settings
 
-`/devmode on`: turn on devmode
-`/devmode off`: turn off devmode
+`.devmode on`: turn on devmode
+`.devmode off`: turn off devmode
 
 #### Stream commands ####
 
-`/stream sleep`: Put the stream into a light sleep mode. Stops sending data, but keeps ffmpeg alive 
+`.stream sleep`: Put the stream into a light sleep mode. Stops sending data, but keeps ffmpeg alive 
 to save bandwidth and performance when nobody is watching the stream. This may not have much use 
 right now, but will be built upon to add toggleable auto sleep functionality.
 Currently still allows robot movement in this mode
 
-`/stream wakeup`: wake up the stream. No automatic code is setup to use this yet, 
+`.stream wakeup`: wake up the stream. No automatic code is setup to use this yet, 
 but it can be put in a button or typed
 
-`/stream reset`: reset just the stream by disabling and re-enabling. 
+`.stream reset`: reset just the stream by disabling and re-enabling. 
 Does not disable movement while it re-connects
 
-`/bitrate {number in kb}`: Adjust the video bitrate (in kilobytes). (ex `/bitrate 1024`)
+`.bitrate {number in kb}`: Adjust the video bitrate (in kilobytes). (ex `/bitrate 1024`)
 
  
 ### Ways to stop the robot:
@@ -122,7 +122,7 @@ Does not disable movement while it re-connects
  
  - Swipe app away from recents
  
- - typing `/estop` in the chat. Will send a `stop` command to the hardware then kill the app forcibly
+ - typing `.estop` in the chat. Will send a `stop` command to the hardware then kill the app forcibly
 
 ### App Permissions ###
 

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/components/RemoCommandHandler.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/components/RemoCommandHandler.kt
@@ -14,8 +14,8 @@ import kotlin.system.exitProcess
  * Handle and potentially filter controls/commands.
  * Any commands not handled through Android will get sent the the robot if possible.
  *
- * ex. `/devmode on` will get processed in Android, and not sent to the bot,
- * but `/speed 100` is not processed, and will get sent to the bot as is
+ * ex. `.devmode on` will get processed in Android, and not sent to the bot,
+ * but `.speed 100` is not processed, and will get sent to the bot as is
  *
  * Commands can come from a button or from the chat. Commands from chat are only able to be used
  * by the owner and moderators
@@ -59,7 +59,7 @@ class RemoCommandHandler : Component(){
     private fun handleCommand(packet: Packet) {
         val command = packet.message
         when {
-            command == "/estop" -> {
+            command == ".estop" -> {
                 sendChat("Shutting Down...")
                 sendHardwareCommand("stop")
                 exclusiveUser = ""
@@ -67,14 +67,14 @@ class RemoCommandHandler : Component(){
                     exitProcess(0)
                 }, 500)
             }
-            command == "/stationary" -> handleStationary(packet)
-            command == "/table on" -> handleStationary(packet, true)
-            command == "/table off" -> handleStationary(packet, false)
-            command == "/devmode on" -> handleDevMode(packet, true)
-            command == "/devmode off" -> handleDevMode(packet, false)
-            command.startsWith("/bitrate") -> handleVideoAudioCommand(command)
-            command.startsWith("/stream") || command.startsWith("/audio") -> handleVideoAudioCommand(command)
-            command.contains("/xcontrol") -> parseXControl(packet)
+            command == ".stationary" -> handleStationary(packet)
+            command == ".table on" -> handleStationary(packet, true)
+            command == ".table off" -> handleStationary(packet, false)
+            command == ".devmode on" -> handleDevMode(packet, true)
+            command == ".devmode off" -> handleDevMode(packet, false)
+            command.startsWith(".bitrate") -> handleVideoAudioCommand(command)
+            command.startsWith(".stream") || command.startsWith("/audio") -> handleVideoAudioCommand(command)
+            command.contains(".xcontrol") -> parseXControl(packet)
             else -> processCommand(packet)
         }
     }

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/components/StreamCommandHandler.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/components/StreamCommandHandler.kt
@@ -41,15 +41,15 @@ class StreamCommandHandler(val context: Context?, val streamHandler : CommandStr
     private fun handleStringCommand(data: String) {
         context?:return
         when {
-            data == "/stream sleep" -> {
+            data == ".stream sleep" -> {
                 sleepMode = true
                 streamHandler.acquireRetriever().disable()
             }
-            data == "/stream wakeup" -> {
+            data == ".stream wakeup" -> {
                 sleepMode = false
                 streamHandler.acquireRetriever().enable(context, streamHandler.pullStreamInfo())
             }
-            data == "/stream reset" -> {
+            data == ".stream reset" -> {
                 sleepMode = false
                 reload()
             }

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/components/audio/RemoAudioComponent.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/components/audio/RemoAudioComponent.kt
@@ -67,17 +67,17 @@ class RemoAudioComponent : AudioComponent() , CommandStreamHandler {
 
     override fun onRegisterCustomCommands(): ArrayList<CommandSubscriptionData>? {
         return ArrayList<CommandSubscriptionData>().apply {
-            add(CommandSubscriptionData(false, "/audio bitrate "){ bitrateString ->
+            add(CommandSubscriptionData(false, ".audio bitrate "){ bitrateString ->
                 setNewBitrate(bitrateString.toInt())
             })
-            add(CommandSubscriptionData(false, "/audio mute"){
+            add(CommandSubscriptionData(false, ".audio mute"){
                 disableInternal()
                 "audio muted".also { text ->
                     sendChatUp(text)
                     ChatUtil.sendToSiteChat(eventDispatcher,text)
                 }
             })
-            add(CommandSubscriptionData(false, "/audio unmute"){
+            add(CommandSubscriptionData(false, ".audio unmute"){
                 super.enableInternal()
                 ChatUtil.sendToSiteChat(eventDispatcher,"audio unmuted")
                 sendChatUp("The Microphone is back on")

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/components/video/RemoVideoComponent.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/components/video/RemoVideoComponent.kt
@@ -78,7 +78,7 @@ class RemoVideoComponent : VideoComponent(), CommandStreamHandler {
 
     override fun onRegisterCustomCommands(): ArrayList<CommandSubscriptionData>? {
         return ArrayList<CommandSubscriptionData>().apply {
-            add(CommandSubscriptionData(false, "/bitrate "){ bitrateString ->
+            add(CommandSubscriptionData(false, ".bitrate "){ bitrateString ->
                 setNewBitrate(bitrateString.toInt())
             })
         }


### PR DESCRIPTION
Fixes https://github.com/remotv/controller-for-android/issues/68

`/` commands will no longer work, and also will not be processed as a chat message