### PR TITLE
Experimental auto sleep support and settings saving capabilities via Prefs helper class

### DIFF
--- a/sdk/src/main/java/tv/remo/android/controller/sdk/RemoSettingsUtil.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/RemoSettingsUtil.kt
@@ -68,6 +68,10 @@ class RemoSettingsUtil(context : Context, sharedPreferences: SharedPreferences) 
     val keepScreenOn = BooleanPref(context, sharedPreferences, R.string.displayPersistKey, false)
     val hideScreenControls = BooleanPref(context, sharedPreferences, R.string.autoHideControlsEnabledKey, false)
 
+    //misc settings
+    val streamSleepMode = BooleanPref(context, sharedPreferences, R.string.streamAutoSleepEnabledKey, false)
+    val streamSleepTimeOut = IntPref(context, sharedPreferences, R.string.streamAutoSleepTimeoutKey, 5*60) //5 minutes
+
     companion object{
         private var INSTANCE : RemoSettingsUtil? = null
 

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/components/RemoCommandHandler.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/components/RemoCommandHandler.kt
@@ -7,6 +7,7 @@ import org.btelman.controlsdk.models.Component
 import org.btelman.controlsdk.models.ComponentEventObject
 import org.btelman.controlsdk.tts.TTSBaseComponent
 import tv.remo.android.controller.sdk.RemoSettingsUtil
+import tv.remo.android.controller.sdk.interfaces.RemoCommandSender
 import tv.remo.android.controller.sdk.models.api.User
 import tv.remo.android.controller.sdk.utils.ChatUtil
 import kotlin.system.exitProcess
@@ -21,7 +22,7 @@ import kotlin.system.exitProcess
  * Commands can come from a button or from the chat. Commands from chat are only able to be used
  * by the owner and moderators
  */
-class RemoCommandHandler : Component(){
+class RemoCommandHandler : Component(), RemoCommandSender {
     private var devModeEnabled = false
     private var stationary = false
     private var serverOwner = ""

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/components/RemoSocketComponent.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/components/RemoSocketComponent.kt
@@ -13,6 +13,7 @@ import org.btelman.controlsdk.models.ComponentEventObject
 import org.btelman.controlsdk.tts.TTSBaseComponent
 import org.json.JSONObject
 import tv.remo.android.controller.sdk.RemoSettingsUtil
+import tv.remo.android.controller.sdk.interfaces.RemoCommandSender
 import tv.remo.android.controller.sdk.models.api.*
 import tv.remo.android.controller.sdk.utils.ChatUtil
 import tv.remo.android.controller.sdk.utils.EndpointBuilder
@@ -24,7 +25,7 @@ import tv.remo.android.controller.sdk.utils.isUrl
  *
  * Note: Do not instantiate in the activity! Must pass it to the ControlSDK Service
  */
-class RemoSocketComponent : Component() {
+class RemoSocketComponent : Component() , RemoCommandSender {
     private var socket: WebSocket? = null
     var apiKey : String? = null
     var activeChannelId : String? = null

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/components/StreamCommandHandler.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/components/StreamCommandHandler.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import org.btelman.controlsdk.models.ComponentEventObject
 import org.btelman.controlsdk.streaming.models.StreamInfo
 import tv.remo.android.controller.sdk.interfaces.CommandStreamHandler
+import tv.remo.android.controller.sdk.interfaces.RemoCommandSender
 import tv.remo.android.controller.sdk.models.api.Channel
 import tv.remo.android.controller.sdk.utils.EndpointBuilder
 
@@ -20,7 +21,7 @@ class StreamCommandHandler(val context: Context?, val streamHandler : CommandStr
     private val subscriptionList = streamHandler.onRegisterCustomCommands()
 
     fun handleExternalMessage(message: ComponentEventObject){
-        if(message.source is RemoSocketComponent || message.source is RemoCommandHandler){
+        if(message.source is RemoCommandSender){
             handleSocketCommand(message)
         }
     }

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/components/audio/RemoAudioComponent.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/components/audio/RemoAudioComponent.kt
@@ -14,6 +14,7 @@ import tv.remo.android.controller.sdk.components.RemoCommandHandler
 import tv.remo.android.controller.sdk.components.RemoSocketComponent
 import tv.remo.android.controller.sdk.components.StreamCommandHandler
 import tv.remo.android.controller.sdk.interfaces.CommandStreamHandler
+import tv.remo.android.controller.sdk.interfaces.RemoCommandSender
 import tv.remo.android.controller.sdk.models.CommandSubscriptionData
 import tv.remo.android.controller.sdk.utils.ChatUtil
 
@@ -38,7 +39,7 @@ class RemoAudioComponent : AudioComponent() , CommandStreamHandler {
     }
 
     override fun handleExternalMessage(message: ComponentEventObject): Boolean {
-        if(message.source is RemoSocketComponent || message.source is RemoCommandHandler){
+        if(message.source is RemoCommandSender){
             commandHandler?.handleExternalMessage(message)
         }
         return super.handleExternalMessage(message)

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/components/hardware/HardwareWatchdogComponent.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/components/hardware/HardwareWatchdogComponent.kt
@@ -50,9 +50,11 @@ class HardwareWatchdogComponent : Component(), RemoCommandSender{
         if(message.type == ComponentType.HARDWARE){
             when(message.what){
                 EVENT_MAIN -> {
-                    if(message.data as? String != "stop"){
-                        maybeStartSleepTimer()
-                        resetTimeout()
+                    (message.data as? String)?.let {
+                        if(it != "stop"){
+                            maybeStartSleepTimer()
+                            resetTimeout()
+                        }
                     }
                 }
             }
@@ -133,12 +135,12 @@ class HardwareWatchdogComponent : Component(), RemoCommandSender{
     private fun maybeStartSleepTimer() {
         if(sleepEnabled && !sleepMode){
             killSleepTimer()
-            handler.postDelayed(sleepRobot, streamSleepTime)
+            handler.postDelayed(sleepRobot, streamSleepTime*1000)
         }
     }
 
     private val sleepRobot = Runnable {
-        eventDispatcher?.handleMessage(ComponentType.CUSTOM, EVENT_MAIN, ".stream sleep", this)
+        eventDispatcher?.handleMessage(ComponentType.HARDWARE, EVENT_MAIN, ".stream sleep", this as RemoCommandSender)
         killSleepTimer()
     }
 

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/components/hardware/HardwareWatchdogComponent.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/components/hardware/HardwareWatchdogComponent.kt
@@ -1,8 +1,15 @@
 package tv.remo.android.controller.sdk.components.hardware
 
+import android.content.Context
+import android.os.Bundle
 import org.btelman.controlsdk.enums.ComponentType
 import org.btelman.controlsdk.models.Component
 import org.btelman.controlsdk.models.ComponentEventObject
+import tv.remo.android.controller.sdk.RemoSettingsUtil
+import tv.remo.android.controller.sdk.components.RemoCommandHandler
+import tv.remo.android.controller.sdk.components.RemoSocketComponent
+import tv.remo.android.controller.sdk.interfaces.RemoCommandSender
+import tv.remo.android.controller.sdk.utils.ChatUtil
 
 /**
  * Watchdog component that will send a stop command
@@ -10,7 +17,27 @@ import org.btelman.controlsdk.models.ComponentEventObject
  *
  * Not useful if non drive motors are still being controlled after timeout, so solution should really be handled on the bot
  */
-class HardwareWatchdogComponent : Component() {
+class HardwareWatchdogComponent : Component(), RemoCommandSender{
+    private var sleepMode = false
+    /**
+     * time in seconds to wait to sleep the stream
+     */
+    private var streamSleepTime: Long = 5*60 //default if settings fails
+    private var sleepEnabled = false
+
+    override fun onInitializeComponent(applicationContext: Context, bundle: Bundle?) {
+        super.onInitializeComponent(applicationContext, bundle)
+        reloadSleepSettings(applicationContext)
+    }
+
+    private fun reloadSleepSettings(maybeContext: Context?) {
+        val context = maybeContext?:return
+        RemoSettingsUtil.with(context){ settings ->
+            sleepEnabled = settings.streamSleepMode.getPref()
+            streamSleepTime = settings.streamSleepTimeOut.getPref().toLong()
+        }
+    }
+
     override fun disableInternal() {
         //not needed
     }
@@ -23,11 +50,96 @@ class HardwareWatchdogComponent : Component() {
         if(message.type == ComponentType.HARDWARE){
             when(message.what){
                 EVENT_MAIN -> {
+                    if(message.data as? String != "stop"){
+                        maybeStartSleepTimer()
+                    }
                     resetTimeout()
                 }
             }
         }
+        else if(message.source is RemoCommandSender){
+            (message.data as? String)?.let {
+                handleStringCommand(message.data as String)
+            }
+        }
         return super.handleExternalMessage(message)
+    }
+
+    private fun handleStringCommand(data: String) {
+        context?:return
+        when (data) {
+            ".stream sleep" -> {
+                if(!sleepMode){
+                    sleepMode = true
+                    killSleepTimer()
+                }
+            }
+            ".stream wakeup" -> {
+                if(sleepMode) {
+                    maybeStartSleepTimer()
+                    sleepMode = false
+                }
+            }
+            ".stream reset" -> {
+                maybeStartSleepTimer()
+                sleepMode = false
+            }
+            else -> {
+                if(data.startsWith(".stream sleeptime ")){
+                    handleSleepCommand(data.replace(".stream sleeptime ", "").trim())
+                }
+            }
+        }
+    }
+
+    private fun handleSleepCommand(data: String) {
+        var maybeTime : Int? = null
+        kotlin.runCatching {
+            maybeTime = data.toInt()
+        }
+        maybeTime?.let { time ->
+            val chatMessage : String = if(time > 0){
+                saveSleepTime(time)
+                "Setting sleeptime to $maybeTime seconds"
+            } else{
+                saveSleepTime(-1)
+                "Setting sleeptime to disabled (time < 0)"
+            }
+            killSleepTimer()
+            maybeStartSleepTimer()
+            ChatUtil.sendToSiteChat(eventDispatcher, chatMessage)
+        } ?: run{
+            ChatUtil.sendToSiteChat(eventDispatcher, ".stream sleeptime {seconds}")
+        }
+    }
+
+    private fun saveSleepTime(time: Int){
+        val context = context?:return
+        RemoSettingsUtil.with(context){ settings ->
+            settings.streamSleepMode.savePref(time > 0)
+            settings.streamSleepTimeOut.savePref(time)
+            reloadSleepSettings(context)
+        }
+    }
+
+
+    private fun killSleepTimer(){
+        handler.removeCallbacks(sleepRobot)
+    }
+
+    /**
+     * Reset the sleep counter when called.
+     */
+    private fun maybeStartSleepTimer() {
+        if(sleepEnabled && !sleepMode){
+            killSleepTimer()
+            handler.postDelayed(sleepRobot, streamSleepTime)
+        }
+    }
+
+    private val sleepRobot = Runnable {
+        eventDispatcher?.handleMessage(ComponentType.CUSTOM, EVENT_MAIN, ".stream sleep", this)
+        killSleepTimer()
     }
 
     private val runnable = Runnable {

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/components/hardware/HardwareWatchdogComponent.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/components/hardware/HardwareWatchdogComponent.kt
@@ -51,10 +51,10 @@ class HardwareWatchdogComponent : Component(), RemoCommandSender{
             when(message.what){
                 EVENT_MAIN -> {
                     (message.data as? String)?.let {
-                        if(it != "stop"){
-                            maybeStartSleepTimer()
-                            resetTimeout()
+                        if(it != "stop" && !it.startsWith(".")){
+                            maybeResetSleepTimer()
                         }
+                        resetTimeout()
                     }
                 }
             }

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/components/hardware/HardwareWatchdogComponent.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/components/hardware/HardwareWatchdogComponent.kt
@@ -52,8 +52,8 @@ class HardwareWatchdogComponent : Component(), RemoCommandSender{
                 EVENT_MAIN -> {
                     if(message.data as? String != "stop"){
                         maybeStartSleepTimer()
+                        resetTimeout()
                     }
-                    resetTimeout()
                 }
             }
         }

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/components/video/RemoVideoComponent.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/components/video/RemoVideoComponent.kt
@@ -12,6 +12,7 @@ import tv.remo.android.controller.sdk.components.RemoSocketComponent
 import tv.remo.android.controller.sdk.components.StreamCommandHandler
 import tv.remo.android.controller.sdk.components.StreamCommandHandler.Companion.rebuildStream
 import tv.remo.android.controller.sdk.interfaces.CommandStreamHandler
+import tv.remo.android.controller.sdk.interfaces.RemoCommandSender
 import tv.remo.android.controller.sdk.models.CommandSubscriptionData
 import tv.remo.android.controller.sdk.utils.ChatUtil
 
@@ -36,7 +37,7 @@ class RemoVideoComponent : VideoComponent(), CommandStreamHandler {
     }
 
     override fun handleExternalMessage(message: ComponentEventObject): Boolean {
-        if(message.source is RemoSocketComponent || message.source is RemoCommandHandler){
+        if(message.source is RemoCommandSender){
             commandHandler?.handleExternalMessage(message)
         }
         return super.handleExternalMessage(message)

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/interfaces/RemoCommandSender.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/interfaces/RemoCommandSender.kt
@@ -1,0 +1,6 @@
+package tv.remo.android.controller.sdk.interfaces
+
+/**
+ * Interface that can be added to components for some other components to see it as a valid command
+ */
+interface RemoCommandSender

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/models/BooleanPref.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/models/BooleanPref.kt
@@ -12,4 +12,8 @@ class BooleanPref(
     override fun getPref(): Boolean {
         return sharedPreferences.getBoolean(key, defaultValue)
     }
+
+    override fun savePref(value: Boolean) {
+        sharedPreferences.edit().putBoolean(key, value).apply()
+    }
 }

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/models/ClassPref.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/models/ClassPref.kt
@@ -17,4 +17,8 @@ class ClassPref(context : Context, sharedPreferences: SharedPreferences, resId: 
             defaultValue
         }
     }
+
+    override fun savePref(value: Class<*>) {
+        sharedPreferences.edit().putString(key, value.name).apply()
+    }
 }

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/models/IntPref.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/models/IntPref.kt
@@ -19,4 +19,8 @@ class IntPref(
             sharedPreferences.getString(key, defaultValue.toString())?.toInt() ?: defaultValue
         }
     }
+
+    override fun savePref(value: Int) {
+        sharedPreferences.edit().putInt(key, value).apply()
+    }
 }

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/models/Pref.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/models/Pref.kt
@@ -15,4 +15,5 @@ abstract class Pref<T>(
     val key : String = context.getString(resId)
 ) {
     abstract fun getPref() : T
+    abstract fun savePref(value : T)
 }

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/models/StringPref.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/models/StringPref.kt
@@ -12,4 +12,8 @@ open class StringPref(
     override fun getPref(): String {
         return sharedPreferences.getString(key, defaultValue)?: defaultValue
     }
+
+    override fun savePref(value: String) {
+        sharedPreferences.edit().putString(key, value).apply()
+    }
 }

--- a/sdk/src/main/res/values/preferences.xml
+++ b/sdk/src/main/res/values/preferences.xml
@@ -47,4 +47,6 @@
     <string name="ffmpegFilterAddition">ffmpegVFPrefsKey</string>
     <string name="ffmpegInputOptionsPrefsKey">ffmpegInputOptions</string>
     <string name="ffmpegOutputOptionsPrefsKey">ffmpegOutputOptions</string>
+    <string name="streamAutoSleepEnabledKey">streamAutoSleepEnabled</string>
+    <string name="streamAutoSleepTimeoutKey">streamAutoSleepTimeout</string>
 </resources>


### PR DESCRIPTION
`.stream sleeptime {number}`

By default this is disabled, and currently is a chat only command. Does not take effect until controls are used, but will probably be changed to start counting down when the bot is turned on right away