### PR TITLE
Fix crashes due to activity being destroyed

### DIFF
--- a/app/src/main/java/tv/remo/android/controller/ui/RemoStatusView.kt
+++ b/app/src/main/java/tv/remo/android/controller/ui/RemoStatusView.kt
@@ -80,7 +80,7 @@ class RemoStatusView @JvmOverloads constructor(
     fun <T : Component> registerStatusEvents(statusClassName : Class<T>){
         broadcastManager.unregisterReceiver(receiver)
         val filter = IntentFilter(StatusBroadcasterComponent.ACTION_SERVICE_STATUS)
-        StatusBroadcasterComponent.generateComponentStatusAction(statusClassName).also {
+        StatusBroadcasterComponent.generateComponentStatusAction(statusClassName.name).also {
             filter.addAction(it)
             log.d { "switching log to $it" }
             log = RemoApplication.getLogger(this, it)

--- a/sdk/src/main/java/tv/remo/android/controller/sdk/components/StatusBroadcasterComponent.kt
+++ b/sdk/src/main/java/tv/remo/android/controller/sdk/components/StatusBroadcasterComponent.kt
@@ -1,7 +1,9 @@
 package tv.remo.android.controller.sdk.components
 
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.os.Bundle
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import org.btelman.controlsdk.enums.ComponentStatus
@@ -14,13 +16,30 @@ import org.btelman.logutil.kotlin.LogUtil
  * Broadcast the statuses of each component, and some service level events
  */
 class StatusBroadcasterComponent : IListener {
-    private val log = LogUtil("StatusBroadcasterComponent", ControlSDKService.loggerID)
+    private val cachedStatus = HashMap<String, ComponentStatus>()
     var localBroadcastManager : LocalBroadcastManager? = null
+    private val receiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if(intent?.action == ACTION_UPDATE){ //something wants us to send all events
+                log.d{
+                    "status update request received by BroadcastReceiver"
+                }
+                //loop through cached statuses and send them
+                cachedStatus.forEach{
+                    handleStatusBroadcast(it.key, it.value)
+                }
+            }
+        }
+    }
+
     override fun onInitializeComponent(applicationContext: Context, bundle: Bundle?) {
         localBroadcastManager = LocalBroadcastManager.getInstance(applicationContext)
+        localBroadcastManager?.registerReceiver(receiver, IntentFilter(ACTION_UPDATE))
     }
 
     override fun onRemoved() {
+        cachedStatus.clear()
+        localBroadcastManager?.unregisterReceiver(receiver)
         localBroadcastManager = null
     }
 
@@ -37,16 +56,21 @@ class StatusBroadcasterComponent : IListener {
     }
 
     override fun onComponentStatus(clazz: Class<*>, componentStatus: ComponentStatus) {
-        log.d{
-            "STATUS_EVENT $componentStatus from ${clazz.name}"
-        }
         super.onComponentStatus(clazz, componentStatus)
+        cachedStatus[clazz.name] = componentStatus //cache it for use if we get a broadcast to update immediately
+        handleStatusBroadcast(clazz.name, componentStatus)
+    }
+
+    private fun handleStatusBroadcast(name: String, componentStatus: ComponentStatus) {
+        log.d{
+            "STATUS_EVENT $componentStatus from $name sending"
+        }
         val intent = Intent(ACTION_COMPONENT_STATUS).apply {
-            putExtra(CLASS_NAME, clazz.name)
+            putExtra(CLASS_NAME, name)
             putExtra(STATUS_NAME, componentStatus)
         }
         //create an intent that will only contain a single class of statuses
-        val intentClassLevel = Intent(generateComponentStatusAction(clazz)).apply {
+        val intentClassLevel = Intent(generateComponentStatusAction(name)).apply {
             putExtra(STATUS_NAME, componentStatus)
         }
         //now send both of them
@@ -55,11 +79,24 @@ class StatusBroadcasterComponent : IListener {
     }
 
     companion object{
-        fun <T> generateComponentStatusAction(clazz : Class<T>) : String{
-            return "${clazz.name}.${ACTION_COMPONENT_STATUS}"
+        private val log = LogUtil("StatusBroadcasterComponent", ControlSDKService.loggerID)
+        fun generateComponentStatusAction(clazzName : String) : String{
+            return "${clazzName}.${ACTION_COMPONENT_STATUS}"
+        }
+
+        /**
+         * Send an update broadcast to trigger this class to send status events again.
+         * Useful if the activity is destroyed, but not the service
+         */
+        fun sendUpdateBroadcast(context: Context){
+            log.d{
+                "Request status update"
+            }
+            LocalBroadcastManager.getInstance(context).sendBroadcast(Intent(ACTION_UPDATE))
         }
         const val ACTION_SERVICE_STATUS = "control.sdk.ACTION_SERVICE_STATUS"
         const val ACTION_COMPONENT_STATUS = "ACTION_COMPONENT_STATUS"
+        const val ACTION_UPDATE = "tv.remo.android.controller.sdk.components.StatusBroadcasterComponent.Refresh"
         const val CLASS_NAME = "component.class"
         const val STATUS_NAME = "component.status.name"
     }


### PR DESCRIPTION
- Status UI now can receive current status when activity is recreated, or created for the first time if the service was already running

fixes https://github.com/remotv/controller-for-android/issues/105